### PR TITLE
Add swap_rownames to makePerCellDF 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Authors@R: c(
         person("Aaron", "Lun", role = c("aut", "cre"), email="infinite.monkeys.with.keyboards@gmail.com"),
         person("Davis", "McCarthy", role="aut")
     )
-Version: 1.9.1
-Date: 2022-11-08
+Version: 1.9.2
+Date: 2022-11-18
 License: GPL-3
 Title: Single-Cell RNA-Seq Analysis Utilities
 Description: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,5 +50,5 @@ biocViews:
     DataImport
 LinkingTo: Rcpp, beachmat
 SystemRequirements: C++11
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 NeedsCompilation: yes

--- a/R/makePerCellDF.R
+++ b/R/makePerCellDF.R
@@ -17,6 +17,9 @@
 #' Alternatively, a character or integer vector specifying the dimensionality reduction results to use.
 #' @param prefix.altexps Logical scalar indicating whether \code{\link{altExp}}-derived fields should be prefixed with the name of the alternative Experiment.
 #' @param check.names Logical scalar indicating whether column names of the output should be made syntactically valid and unique.
+#' @param swap_rownames Column name of \code{rowData(object)} to be used to
+#'  identify features instead of \code{rownames(object)} when labelling plot
+#'  elements.
 #' @param exprs_values,use_dimred,use_altexps,prefix_altexps,check_names
 #' Soft-deprecated equivalents of the arguments described above.
 #'

--- a/R/makePerCellDF.R
+++ b/R/makePerCellDF.R
@@ -73,6 +73,9 @@ makePerCellDF <- function(x, features=NULL, assay.type="logcounts",
     prefix.altexps <- .replace(prefix.altexps, prefix_altexps)
     check.names <- .replace(check.names, check_names)
 
+    # Initialize output list
+    output <- list()
+
     # Collecting the column metadata.
     use.coldata <- .use_names_to_integer_indices(use.coldata, x=x, nameFUN=function(x) colnames(colData(x)), msg="use.coldata")
     if (length(use.coldata)) {
@@ -81,7 +84,7 @@ makePerCellDF <- function(x, features=NULL, assay.type="logcounts",
     }
 
     # Collecting feature data
-    output <- list(.harvest_se_by_column(x, features=features, assay.type=assay.type, swap_rownames = swap_rownames))
+    output <- c(output, .harvest_se_by_column(x, features=features, assay.type=assay.type, swap_rownames = swap_rownames))
 
     # Collecting the reduced dimensions.
     use.dimred <- .use_names_to_integer_indices(use.dimred, x=x, nameFUN=reducedDimNames, msg="use.dimred")

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,8 +1,11 @@
 \name{NEWS}
 \title{News for Package \pkg{scuttle}}
 
-\section{Version 1.8.0}{\itemize{
+\section{Version 1.8}{\itemize{
 \item Removed support for \code{use.altexps=} in \code{aggregateAcrossCells()} and \code{logNormCounts()}.
+
+\item Added \code{swap.rownames=} option to \code{makePerCellDF()} to allow easy access by \code{rowData} aliases.
+Also moved the extracted features to the end of the data frame for consistency.
 }}
 
 \section{Version 1.2.0}{\itemize{

--- a/man/makePerCellDF.Rd
+++ b/man/makePerCellDF.Rd
@@ -13,6 +13,7 @@ makePerCellDF(
   use.altexps = TRUE,
   prefix.altexps = FALSE,
   check.names = FALSE,
+  swap.rownames = NULL,
   exprs_values = NULL,
   use_dimred = NULL,
   use_altexps = NULL,
@@ -25,7 +26,7 @@ makePerCellDF(
 This is expected to have non-\code{NULL} row names.}
 
 \item{features}{Character vector specifying the features for which to extract expression profiles across cells.
-May also include features in alternative Experiments if permitted by \code{use_altexps}.}
+May also include features in alternative Experiments if permitted by \code{use.altexps}.}
 
 \item{assay.type}{String or integer scalar indicating the assay to use to obtain expression values.
 Must refer to a matrix-like object with integer or numeric values.}
@@ -42,6 +43,9 @@ Alternatively, a character or integer vector specifying the alternative experime
 \item{prefix.altexps}{Logical scalar indicating whether \code{\link{altExp}}-derived fields should be prefixed with the name of the alternative Experiment.}
 
 \item{check.names}{Logical scalar indicating whether column names of the output should be made syntactically valid and unique.}
+
+\item{swap.rownames}{String specifying the \code{\link{rowData}} column containing the \code{features}.
+If \code{NULL}, \code{rownames(x)} is used.}
 
 \item{exprs_values, use_dimred, use_altexps, prefix_altexps, check_names}{Soft-deprecated equivalents of the arguments described above.}
 }

--- a/tests/testthat/test-make-df.R
+++ b/tests/testthat/test-make-df.R
@@ -46,7 +46,7 @@ test_that("makePerCellDF works as expected", {
     # Do not fix my names unless requested.
     rownames(example_sce) <- paste0("+", seq_len(nrow(example_sce)))
     df0b <- makePerCellDF(example_sce, features=rownames(example_sce)[1:10])
-    expect_identical(colnames(df0b)[1:10], rownames(example_sce)[1:10])
+    expect_identical(tail(colnames(df0b), 10), rownames(example_sce)[1:10])
 
     reducedDimNames(example_sce)[1] <- "+-PCA"
     df0c <- makePerCellDF(example_sce)
@@ -54,7 +54,27 @@ test_that("makePerCellDF works as expected", {
 
     df0d <- makePerCellDF(example_sce, features=rownames(example_sce)[1:10], check.names=TRUE)
     expect_true("X..PCA.1" %in% colnames(df0d))
-    expect_identical(colnames(df0d)[1:10], make.names(rownames(example_sce)[1:10]))
+    expect_identical(tail(colnames(df0d), 10), make.names(rownames(example_sce)[1:10]))
+})
+
+test_that("makePerCellDF works with rowname swapping", {
+    rowData(example_sce)$alias <- sprintf("FEATURE_%s", seq_len(nrow(example_sce)))
+    df1 <- makePerCellDF(example_sce, features="FEATURE_1", swap.rownames="alias")
+    expect_identical(df1$FEATURE_1, unname(logcounts(example_sce)[1,]))
+
+    # Combines easily with altexps.
+    rowData(altExp(example_sce))$alias <- sprintf("thing_%s", seq_len(nrow(altExp(example_sce))))
+    df1 <- makePerCellDF(example_sce, features=c("FEATURE_10", "thing_9"), swap.rownames="alias")
+    expect_identical(df1$FEATURE_10, unname(logcounts(example_sce)[10,]))
+    expect_identical(df1$thing_9, unname(logcounts(altExp(example_sce))[9,]))
+
+    df1 <- makePerCellDF(example_sce, features=c("FEATURE_10", "thing_9"), swap.rownames="alias", prefix.altexps=TRUE)
+    expect_identical(df1$FEATURE_10, unname(logcounts(example_sce)[10,]))
+    expect_identical(df1$thing.thing_9, unname(logcounts(altExp(example_sce))[9,]))
+
+    # Graceully handles absent swaps.
+    df1 <- makePerCellDF(example_sce, features="FEATURE_1", swap.rownames="alchemist")
+    expect_false(any(grepl("gene|feature", colnames(df1), ignore.case=TRUE)))
 })
 
 test_that("makePerFeatureDF works as expected", {


### PR DESCRIPTION
Hi @LTLA,

Here is PR mentioned in #18.

It contains the following changes:
- Change order to DF creation so that colData is always prior to feature data (discrepancy mention in #18 but if this was intentional design choice these changes can be reverted).
- Added two internal functions from scater package (`.swap_rownames` and `.get_rowData_column`) Lines 147-166.  
- Added `swap_rownames` parameter to `makePerCellDF` and `.harvest_se_by_column`
- Rstudio also removed a bunch of trailing spaces when file was saved so those appear in commit as well.

Let me know if there are any additional changes or reversions that you would like and I'm happy to work on those as well.

Thanks!
Sam