### PR TITLE
Add na.rm to aggregating functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,9 +2,10 @@ Package: scuttle
 Type: Package
 Authors@R: c(
         person("Aaron", "Lun", role = c("aut", "cre"), email="infinite.monkeys.with.keyboards@gmail.com"),
-        person("Davis", "McCarthy", role="aut")
+        person("Davis", "McCarthy", role="aut"),
+        person("Tuomas", "Borman", role = "ctb", comment = c(ORCID = "0000-0002-8563-8884"))
     )
-Version: 1.15.5
+Version: 1.15.6
 Date: 2024-10-26
 License: GPL-3
 Title: Single-Cell RNA-Seq Analysis Utilities

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -29,7 +29,7 @@ sparse_aggregate_detected <- function(x, i, p, groupings, ngroups, nrows) {
     .Call(`_scuttle_sparse_aggregate_detected`, x, i, p, groupings, ngroups, nrows)
 }
 
-sum_row_counts <- function(counts, genes, runs) {
-    .Call(`_scuttle_sum_row_counts`, counts, genes, runs)
+sum_row_counts <- function(counts, genes, runs, average = FALSE, na_rm = FALSE) {
+    .Call(`_scuttle_sum_row_counts`, counts, genes, runs, average, na_rm)
 }
 

--- a/R/numDetectedAcrossCells.R
+++ b/R/numDetectedAcrossCells.R
@@ -40,7 +40,7 @@ NULL
 #' @importFrom SummarizedExperiment assayNames<-
 .nexprs_across_cells <- function(x, ids, subset.row=NULL, subset.col=NULL, 
     store.number="ncells", average=FALSE, threshold=0, BPPARAM=SerialParam(),
-    subset_row=NULL, subset_col=NULL, store_number=NULL, detection_limit=NULL)
+    subset_row=NULL, subset_col=NULL, store_number=NULL, detection_limit=NULL, ...)
 {
     subset.row <- .replace(subset.row, subset_row)
     subset.col <- .replace(subset.col, subset_col)
@@ -54,7 +54,7 @@ NULL
     }
 
     output <- summarizeAssayByGroup(x, ids, subset.row=subset.row, subset.col=subset.col,
-        statistics=stat, store.number=store.number, threshold=threshold, BPPARAM=BPPARAM)
+        statistics=stat, store.number=store.number, threshold=threshold, BPPARAM=BPPARAM, ...)
 
     if (average) {
         assayNames(output) <- "average"

--- a/R/numDetectedAcrossFeatures.R
+++ b/R/numDetectedAcrossFeatures.R
@@ -33,14 +33,14 @@ NULL
 #' @importFrom BiocParallel SerialParam 
 .nexprs_across_features <- function(x, ids, subset.row=NULL, subset.col=NULL, 
     average=FALSE, threshold=0, BPPARAM=SerialParam(), 
-    subset_row=NULL, subset_col=NULL, detection_limit=NULL)
+    subset_row=NULL, subset_col=NULL, detection_limit=NULL, ...)
 {
     subset.row <- .replace(subset.row, subset_row)
     subset.col <- .replace(subset.col, subset_col)
     threshold <- .replace(threshold, detection_limit)
 
     .sum_across_features(x, ids, subset.row=subset.row, subset.col=subset.col, 
-        average=average, BPPARAM=BPPARAM, modifier=function(x) x > threshold)
+        average=average, BPPARAM=BPPARAM, modifier=function(x) x > threshold, ...)
 } 
 
 #' @export

--- a/R/sumCountsAcrossFeatures.R
+++ b/R/sumCountsAcrossFeatures.R
@@ -66,16 +66,18 @@ NULL
 
 #' @importFrom BiocParallel SerialParam 
 .sum_counts_across_features <- function(x, ids, subset.row=NULL, subset.col=NULL, 
-    average=FALSE, BPPARAM=SerialParam(), subset_row=NULL, subset_col=NULL) 
+    average=FALSE, BPPARAM=SerialParam(), subset_row=NULL, subset_col=NULL, ...) 
 {
     subset.row <- .replace(subset.row, subset_row)
     subset.col <- .replace(subset.col, subset_col)
-    .sum_across_features(x, ids, subset.row=subset.row, subset.col=subset.col, average=average, BPPARAM=BPPARAM)
+    .sum_across_features(x, ids, subset.row=subset.row, subset.col=subset.col, average=average, BPPARAM=BPPARAM, ...)
 }
 
 #' @importFrom BiocParallel SerialParam
 #' @importFrom beachmat colBlockApply
-.sum_across_features <- function(x, ids, subset.row=NULL, subset.col=NULL, average=FALSE, BPPARAM=SerialParam(), modifier=NULL) {
+.sum_across_features <- function(x, ids, subset.row=NULL, subset.col=NULL, average=FALSE, BPPARAM=SerialParam(), modifier=NULL, na.rm = na_rm, na_rm = FALSE, ...) {
+    if( !(is.logical(na.rm) && length(na.rm) == 1L) ) stop("'na.rm' must be TRUE or FALSE.")
+    #
     if (is.list(ids)) {
         ids <- lapply(ids, FUN=.subset2index, target=x, byrow=TRUE)
         runs <- lengths(ids)
@@ -106,14 +108,10 @@ NULL
         x <- modifier(x)
     }
 
-    out_list <- colBlockApply(x, BPPARAM=BPPARAM, FUN=sum_row_counts, genes=genes, runs=runs)
+    out_list <- colBlockApply(x, BPPARAM=BPPARAM, FUN=sum_row_counts, genes=genes, runs=runs, average=average, na_rm = na.rm, ...)
     out <- do.call(cbind, out_list)
     rownames(out) <- names
     colnames(out) <- colnames(x)
-
-    if (average) {
-        out <- out/runs
-    }
 
     out
 }

--- a/R/summarizeAssayByGroup.R
+++ b/R/summarizeAssayByGroup.R
@@ -156,16 +156,40 @@ NULL
         collected <- do.call(mapply, c(list(FUN=rbind, SIMPLIFY=FALSE, USE.NAMES=FALSE), out))
         names(collected) <- names(out[[1]])
 
-        freq <- lengths(by.group)
+        # Calculate frequency matrix with dimensions genes*cells and apply
+        # that to get average abundance and proportion of detected genes.
+        freq <- .calculate_frequency(x, by.group, ...)
         if ("mean" %in% statistics) {
-            collected$mean <- t(t(collected$sum)/freq)
+            collected$mean <- collected$sum/freq
         }
         if ("prop.detected" %in% statistics) {
-            collected$prop.detected <- t(t(collected$num.detected)/freq)
+            collected$prop.detected <- collected$num.detected/freq
         }
+        # Convert frequencies to single vector so that it can be stored to
+        # colData. Calculate average which is an integer for each group
+        # when there are no NAs.
+        freq <- colMeans(freq)
+        freq <- if(all(freq %% 1 == 0)) as.integer(freq) else freq
     }
 
     list(summary=collected[statistics], freq=freq)
+}
+
+# This function calculates the number of cells within a specific group in which each gene was detected.
+.calculate_frequency <- function(x, by.group, na.rm = FALSE, ...){
+    # If na.rm is specified, we take account only values that are not NA.
+    # Otherwise the frequency is just the number of features in each group.
+    if( na.rm ){
+        x <- !is.na(x)
+        freq <- lapply(by.group, function(i) rowSums(x[,i,drop=FALSE]))
+        freq <- do.call(cbind, freq)
+    } else{
+        # To ensure that the output is in similar format, frequencies are
+        # converted into matrix.
+        freq <- lengths(by.group)
+        freq <- matrix(rep(freq, nrow(x)), nrow=nrow(x), byrow = TRUE)
+    }
+    return(freq)
 }
 
 #' @importFrom MatrixGenerics rowSums rowMedians

--- a/R/summarizeAssayByGroup.R
+++ b/R/summarizeAssayByGroup.R
@@ -78,12 +78,12 @@ NULL
 #' @importFrom SummarizedExperiment SummarizedExperiment
 .summarize_assay_by_group <- function(x, ids, subset.row=NULL, subset.col=NULL,
     statistics=c("mean", "sum", "num.detected", "prop.detected", "median"),
-    store.number="ncells", threshold=0, BPPARAM=SerialParam()) 
+    store.number="ncells", threshold=0, BPPARAM=SerialParam(), ...) 
 {
     new.ids <- .process_ids(x, ids, subset.col)
     sum.out <- .summarize_assay(x, ids=new.ids, subset.row=subset.row,
         statistics=match.arg(statistics, several.ok=TRUE),
-        threshold=threshold, BPPARAM=BPPARAM)
+        threshold=threshold, BPPARAM=BPPARAM, ...)
 
     mat.out <- sum.out$summary
     mapping <- match(colnames(mat.out[[1]]), as.character(new.ids))
@@ -100,7 +100,7 @@ NULL
 
 #' @importFrom BiocParallel SerialParam 
 #' @importFrom beachmat rowBlockApply
-.summarize_assay <- function(x, ids, statistics, threshold=0, subset.row=NULL, BPPARAM=SerialParam()) {
+.summarize_assay <- function(x, ids, statistics, threshold=0, subset.row=NULL, BPPARAM=SerialParam(), ...) {
     if (!is.null(subset.row)) {
         x <- x[subset.row,,drop=FALSE]
     }
@@ -151,7 +151,7 @@ NULL
         by.group <- split(seq_along(ids), ids, drop=TRUE)
 
         out <- rowBlockApply(x, FUN=.summarize_assay_internal, by.group=by.group, 
-            statistics=statistics, threshold=threshold, BPPARAM=BPPARAM)
+            statistics=statistics, threshold=threshold, BPPARAM=BPPARAM, ...)
 
         collected <- do.call(mapply, c(list(FUN=rbind, SIMPLIFY=FALSE, USE.NAMES=FALSE), out))
         names(collected) <- names(out[[1]])
@@ -170,7 +170,7 @@ NULL
 
 #' @importFrom MatrixGenerics rowSums rowMedians
 #' @importClassesFrom SparseArray COO_SparseMatrix SVT_SparseMatrix
-.summarize_assay_internal <- function(x, by.group, statistics, threshold) {
+.summarize_assay_internal <- function(x, by.group, statistics, threshold, ...) {
     if (is(x, "COO_SparseMatrix")) {
         x <- as(x, "SVT_SparseMatrix")
     }
@@ -178,20 +178,20 @@ NULL
     collated <- list()
     
     if ("sum" %in% statistics || "mean" %in% statistics) {
-        out <- lapply(by.group, function(i) rowSums(x[,i,drop=FALSE]))
+        out <- lapply(by.group, function(i) rowSums(x[,i,drop=FALSE], ...))
         collated$sum <- .cbind_empty(out, x)
     }
 
     if ("median" %in% statistics) {
         # This should auto-lookup the various *MatrixStats packages if they're installed.
-        out <- lapply(by.group, function(i) rowMedians(x[,i,drop=FALSE]))
+        out <- lapply(by.group, function(i) rowMedians(x[,i,drop=FALSE], ...))
         out <- .cbind_empty(out, x)
         rownames(out) <- rownames(x)
         collated$median <- out
     }
 
     if ("num.detected" %in% statistics || "prop.detected" %in% statistics) {
-        out <- lapply(by.group, function(i) rowSums(x[,i,drop=FALSE] > threshold))
+        out <- lapply(by.group, function(i) rowSums((x[,i,drop=FALSE] > threshold), ...))
         collated$num.detected <- .cbind_empty(out, x)
     }
 

--- a/man/numDetectedAcrossCells.Rd
+++ b/man/numDetectedAcrossCells.Rd
@@ -20,7 +20,8 @@ numDetectedAcrossCells(x, ...)
   subset_row = NULL,
   subset_col = NULL,
   store_number = NULL,
-  detection_limit = NULL
+  detection_limit = NULL,
+  ...
 )
 
 \S4method{numDetectedAcrossCells}{SummarizedExperiment}(x, ..., assay.type = "counts", exprs_values = NULL)

--- a/man/numDetectedAcrossFeatures.Rd
+++ b/man/numDetectedAcrossFeatures.Rd
@@ -18,7 +18,8 @@ numDetectedAcrossFeatures(x, ...)
   BPPARAM = SerialParam(),
   subset_row = NULL,
   subset_col = NULL,
-  detection_limit = NULL
+  detection_limit = NULL,
+  ...
 )
 
 \S4method{numDetectedAcrossFeatures}{SummarizedExperiment}(x, ..., assay.type = "counts", exprs_values = NULL)

--- a/man/sumCountsAcrossFeatures.Rd
+++ b/man/sumCountsAcrossFeatures.Rd
@@ -16,7 +16,8 @@ sumCountsAcrossFeatures(x, ...)
   average = FALSE,
   BPPARAM = SerialParam(),
   subset_row = NULL,
-  subset_col = NULL
+  subset_col = NULL,
+  ...
 )
 
 \S4method{sumCountsAcrossFeatures}{SummarizedExperiment}(x, ..., assay.type = "counts", exprs_values = NULL)

--- a/man/summarizeAssayByGroup.Rd
+++ b/man/summarizeAssayByGroup.Rd
@@ -16,7 +16,8 @@ summarizeAssayByGroup(x, ...)
   statistics = c("mean", "sum", "num.detected", "prop.detected", "median"),
   store.number = "ncells",
   threshold = 0,
-  BPPARAM = SerialParam()
+  BPPARAM = SerialParam(),
+  ...
 )
 
 \S4method{summarizeAssayByGroup}{SummarizedExperiment}(x, ..., assay.type = "counts")

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -103,14 +103,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // sum_row_counts
-Rcpp::RObject sum_row_counts(Rcpp::RObject counts, Rcpp::IntegerVector genes, Rcpp::IntegerVector runs);
-RcppExport SEXP _scuttle_sum_row_counts(SEXP countsSEXP, SEXP genesSEXP, SEXP runsSEXP) {
+Rcpp::RObject sum_row_counts(Rcpp::RObject counts, Rcpp::IntegerVector genes, Rcpp::IntegerVector runs, bool average, bool na_rm);
+RcppExport SEXP _scuttle_sum_row_counts(SEXP countsSEXP, SEXP genesSEXP, SEXP runsSEXP, SEXP averageSEXP, SEXP na_rmSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< Rcpp::RObject >::type counts(countsSEXP);
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type genes(genesSEXP);
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type runs(runsSEXP);
-    rcpp_result_gen = Rcpp::wrap(sum_row_counts(counts, genes, runs));
+    Rcpp::traits::input_parameter< bool >::type average(averageSEXP);
+    Rcpp::traits::input_parameter< bool >::type na_rm(na_rmSEXP);
+    rcpp_result_gen = Rcpp::wrap(sum_row_counts(counts, genes, runs, average, na_rm));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -123,7 +125,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_scuttle_pool_size_factors", (DL_FUNC) &_scuttle_pool_size_factors, 4},
     {"_scuttle_sparse_aggregate_sum", (DL_FUNC) &_scuttle_sparse_aggregate_sum, 6},
     {"_scuttle_sparse_aggregate_detected", (DL_FUNC) &_scuttle_sparse_aggregate_detected, 6},
-    {"_scuttle_sum_row_counts", (DL_FUNC) &_scuttle_sum_row_counts, 3},
+    {"_scuttle_sum_row_counts", (DL_FUNC) &_scuttle_sum_row_counts, 5},
     {NULL, NULL, 0}
 };
 

--- a/src/sum_counts.cpp
+++ b/src/sum_counts.cpp
@@ -2,30 +2,60 @@
 #include "beachmat3/beachmat.h"
 #include <vector>
 
+// 'counts' is an abundance matrix
+// 'genes' is an integer vector that includes indices for each gene (feature), ordered by group (features from the first group come first, followed by the next group, etc)
+// 'runs' specifies the number of genes in each group, allowing us to split the features in 'genes' into distinct groups for summing
 // [[Rcpp::export(rng=false)]]
-Rcpp::RObject sum_row_counts (Rcpp::RObject counts, Rcpp::IntegerVector genes, Rcpp::IntegerVector runs) {
+Rcpp::RObject sum_row_counts (Rcpp::RObject counts, Rcpp::IntegerVector genes, Rcpp::IntegerVector runs, bool average = false, bool na_rm = false) {
+    // Read the matrix from the 'counts' R object into beachmat format for efficient processing
     auto mat = beachmat::read_lin_block(counts);
 
-    const size_t ncells=mat->get_ncol();
-    std::vector<double> holding(mat->get_nrow());
-    const size_t nsummations=runs.size();
-    Rcpp::NumericMatrix output(nsummations, ncells);
+    const size_t ncells=mat->get_ncol(); // Get the number of columns (cells) in the matrix
+    std::vector<double> holding(mat->get_nrow()); // Vector to hold values for each column of the abundance matrix
+    const size_t nsummations=runs.size(); // Get the number of gene groups (runs) to process
+    Rcpp::NumericMatrix output(nsummations, ncells); // Initialize an output matrix for storing results.
 
+    // Loop over each column of the abundance matrix
     for (size_t c=0; c<ncells; ++c) {
-        auto it = mat->get_col(c, holding.data());
-        auto outcol=output.column(c);
-        auto oIt=outcol.begin();
-        auto gIt=genes.begin();
+        auto it = mat->get_col(c, holding.data()); // Get the values of the current column and store them in holding
+        auto outcol=output.column(c); // Access the current output column to store results for this cell
+        auto oIt=outcol.begin(); // Initialize iterator for the elements/cells of single output column.
+        auto gIt=genes.begin(); // Initialize iterator for the gene indices.
 
+        // Loop over each grouping of genes
         for (auto s : runs) {
+            int run_count = 0; // Track number of genes in the current run
+            double run_sum = 0.0; // Track the sum of gene abundance in the current run
+            
+            // This loop iterates over the specified genes for the current run in the current cell (column), summing their abundance values
             while (s > 0) {
-                (*oIt) += *(it + *gIt - 1); // get back to zero indexing.
-                --s;
-                ++gIt;
+                // Get the abundance of single gene in this column.
+                // '*gIt' is the 1-based index for the gene; subtract 1 for 0-based indexing used in C++
+                double value = *(it + *gIt - 1);
+                
+                // For possible average calculation, get the number of genes that have non-NA value.
+                // If the value is non-NA, we increase the number of detected genes by one.
+                if ( !(std::isnan(value) || value == NA_INTEGER) ) {
+                    ++run_count;
+                }
+                // Replace NA value with 0. This can be done as we are summing values; it does not affect the result.
+                if ( na_rm && (std::isnan(value) || value == NA_INTEGER) ) {
+                    value = 0;
+                }
+                
+                run_sum += value; // Add the gene abundance to the current group sum
+                --s; // Decrement 's' to track how many genes are left to process in this group
+                ++gIt; // Move to the next gene index in the 'genes' vector.
             }
-            ++oIt;
+            // Calculate average abundance of this group
+            if (average && run_count > 0) {
+                run_sum /= run_count;
+            }
+            
+            (*oIt) = run_sum; // Add the abundance to the result matrix in specified cell
+            ++oIt; // Move to next run/group, i.e., next cell of result matrix in specified column
         }
     }
 
     return output;
-} 
+}

--- a/tests/testthat/test-sum-across-cells.R
+++ b/tests/testthat/test-sum-across-cells.R
@@ -554,3 +554,52 @@ test_that("numDetectedAcrossCells handles other matrix classes", {
     delayed <- DelayedArray(thing)
     expect_equal(numDetectedAcrossCells(delayed, ids), ref)
 })
+
+test_that("test that na.rm works correctly", {
+    # Calculate average and sum for each column group
+    summary_FUN_cols <- function(x, ids){
+        # Loop through groups and calculate statistics
+        groups <- unique(ids) |> sort()
+        res <- lapply(groups, function(group){
+            mat_sub <- assay(x[, ids == group ])
+            list(
+                sum = rowSums(mat_sub, na.rm = FALSE),
+                sum_na = rowSums(mat_sub, na.rm = TRUE),
+                mean = rowMeans(mat_sub, na.rm = FALSE),
+                mean_na = rowMeans(mat_sub, na.rm = TRUE)
+            )
+        })
+        # Combine results for each statistic across groups
+        res <- lapply(c("sum", "sum_na", "mean", "mean_na"), function(stat){
+            do.call(cbind, lapply(res, `[[`, stat))
+        })
+        names(res) <- c("sum", "sum_na", "mean", "mean_na")
+        return(res)
+    }
+    # Prepare data
+    sce <- mockSCE()
+    ids <- sample(LETTERS, ncol(sce), replace=TRUE)
+    # Create a data with NAs
+    n_value <- nrow(sce)*ncol(sce)
+    prob <- runif(1, 0, 0.1)
+    sce_na <- sce
+    assay(sce_na)[c(1, 5, 3, 6)] <- NA
+    # Test without NAs
+    res <- summarizeAssayByGroup(sce, ids = ids, na.rm = FALSE)
+    res_na <- summarizeAssayByGroup(sce, ids = ids, na.rm = TRUE)
+    ref <- summary_FUN_cols(sce, ids)
+    #
+    expect_equal(assay(res, "sum"), ref[["sum"]], check.attributes = FALSE)
+    expect_equal(assay(res_na, "sum"), ref[["sum_na"]], check.attributes = FALSE)
+    expect_equal(assay(res, "mean"), ref[["mean"]], check.attributes = FALSE)
+    expect_equal(assay(res_na, "mean"), ref[["mean_na"]], check.attributes = FALSE)
+    # Test with NAs
+    res <- summarizeAssayByGroup(sce_na, ids = ids, na.rm = FALSE)
+    res_na <- summarizeAssayByGroup(sce_na, ids = ids, na.rm = TRUE)
+    ref <- summary_FUN_cols(sce_na, ids)
+    #
+    expect_equal(assay(res, "sum"), ref[["sum"]], check.attributes = FALSE)
+    expect_equal(assay(res_na, "sum"), ref[["sum_na"]], check.attributes = FALSE)
+    expect_equal(assay(res, "mean"), ref[["mean"]], check.attributes = FALSE)
+    expect_equal(assay(res_na, "mean"), ref[["mean_na"]], check.attributes = FALSE)
+})

--- a/tests/testthat/test-sum-across-cells.R
+++ b/tests/testthat/test-sum-across-cells.R
@@ -581,9 +581,10 @@ test_that("test that na.rm works correctly", {
     ids <- sample(LETTERS, ncol(sce), replace=TRUE)
     # Create a data with NAs
     n_value <- nrow(sce)*ncol(sce)
-    prob <- runif(1, 0, 0.1)
+    prob <- runif(1, 0, 0.05)
     sce_na <- sce
-    assay(sce_na)[c(1, 5, 3, 6)] <- NA
+    ind <- sample(c(TRUE, FALSE), size = length(assay(sce_na)), replace = TRUE, prob = c(prob, 1 - prob))
+    assay(sce_na)[ind] <- NA
     # Test without NAs
     res <- summarizeAssayByGroup(sce, ids = ids, na.rm = FALSE)
     res_na <- summarizeAssayByGroup(sce, ids = ids, na.rm = TRUE)

--- a/tests/testthat/test-sum-across-feat.R
+++ b/tests/testthat/test-sum-across-feat.R
@@ -214,3 +214,57 @@ test_that("numDetectedAcrossFeatures handles other matrix classes", {
     delayed <- DelayedArray(thing)
     expect_equal(numDetectedAcrossFeatures(delayed, ids), ref)
 })
+
+test_that("test that na.rm works correctly", {
+    # Calculate average and sum for each row group
+    summary_FUN_rows <- function(x, ids){
+        # Loop through groups and calculate statistics
+        groups <- unique(ids) |> sort()
+        res <- lapply(groups, function(group) {
+            mat_sub <- x[ids == group, ]
+            list(
+                sum = colSums(mat_sub, na.rm = FALSE),
+                sum_na = colSums(mat_sub, na.rm = TRUE),
+                mean = colMeans(mat_sub, na.rm = FALSE),
+                mean_na = colMeans(mat_sub, na.rm = TRUE)
+            )
+        })
+        # Combine results for each statistic across groups
+        res <- lapply(c("sum", "sum_na", "mean", "mean_na"), function(stat) {
+            do.call(rbind, lapply(res, `[[`, stat))
+        })
+        names(res) <- c("sum", "sum_na", "mean", "mean_na")
+        return(res)
+    }
+    # Prepare data
+    sce <- mockSCE()
+    assayNames(sce) <- "counts"
+    ids <- sample(LETTERS, nrow(sce), replace = TRUE)
+    # Create a data with NAs
+    n_value <- nrow(sce)*ncol(sce)
+    prob <- runif(1, 0, 0.1)
+    sce_na <- sce
+    assay(sce_na)[c(1, 5, 3, 6)] <- NA
+    # Test without NAs
+    res_sum <- sumCountsAcrossFeatures(assay(sce), ids = ids, average = FALSE, na.rm = FALSE)
+    res_sum_na <- sumCountsAcrossFeatures(assay(sce), ids = ids, average = FALSE, na.rm = TRUE)
+    res_mean <- sumCountsAcrossFeatures(assay(sce), ids = ids, average = TRUE, na.rm = FALSE)
+    res_mean_na <- sumCountsAcrossFeatures(assay(sce), ids = ids, average = TRUE, na.rm = TRUE)
+    ref <- summary_FUN_rows(assay(sce), ids)
+    #
+    expect_equal(res_sum, ref[["sum"]], check.attributes = FALSE)
+    expect_equal(res_sum_na, ref[["sum_na"]], check.attributes = FALSE)
+    expect_equal(res_mean, ref[["mean"]], check.attributes = FALSE)
+    expect_equal(res_mean_na, ref[["mean_na"]], check.attributes = FALSE)
+    # Test with NAs
+    res_sum <- sumCountsAcrossFeatures(assay(sce_na), ids = ids, average = FALSE, na.rm = FALSE)
+    res_sum_na <- sumCountsAcrossFeatures(assay(sce_na), ids = ids, average = FALSE, na.rm = TRUE)
+    res_mean <- sumCountsAcrossFeatures(assay(sce_na), ids = ids, average = TRUE, na.rm = FALSE)
+    res_mean_na <- sumCountsAcrossFeatures(assay(sce_na), ids = ids, average = TRUE, na.rm = TRUE)
+    ref <- summary_FUN_rows(assay(sce_na), ids)
+    #
+    expect_equal(res_sum, ref[["sum"]], check.attributes = FALSE)
+    expect_equal(res_sum_na, ref[["sum_na"]], check.attributes = FALSE)
+    expect_equal(res_mean, ref[["mean"]], check.attributes = FALSE)
+    expect_equal(res_mean_na, ref[["mean_na"]], check.attributes = FALSE)
+})

--- a/tests/testthat/test-sum-across-feat.R
+++ b/tests/testthat/test-sum-across-feat.R
@@ -238,7 +238,6 @@ test_that("test that na.rm works correctly", {
     }
     # Prepare data
     sce <- mockSCE()
-    assayNames(sce) <- "counts"
     ids <- sample(LETTERS, nrow(sce), replace = TRUE)
     # Create a data with NAs
     n_value <- nrow(sce)*ncol(sce)

--- a/tests/testthat/test-sum-across-feat.R
+++ b/tests/testthat/test-sum-across-feat.R
@@ -241,9 +241,10 @@ test_that("test that na.rm works correctly", {
     ids <- sample(LETTERS, nrow(sce), replace = TRUE)
     # Create a data with NAs
     n_value <- nrow(sce)*ncol(sce)
-    prob <- runif(1, 0, 0.1)
+    prob <- runif(1, 0, 0.05)
     sce_na <- sce
-    assay(sce_na)[c(1, 5, 3, 6)] <- NA
+    ind <- sample(c(TRUE, FALSE), size = length(assay(sce_na)), replace = TRUE, prob = c(prob, 1 - prob))
+    assay(sce_na)[ind] <- NA
     # Test without NAs
     res_sum <- sumCountsAcrossFeatures(assay(sce), ids = ids, average = FALSE, na.rm = FALSE)
     res_sum_na <- sumCountsAcrossFeatures(assay(sce), ids = ids, average = FALSE, na.rm = TRUE)


### PR DESCRIPTION
This PR adds `na.rm` option to following functions: `sumCountsAcrossFeatures`, `numDetectedAcrossFeatures`, `summarizeAssayByGroup`, `numDetectedAcrossCells`.

This PR is related to this issue: https://github.com/LTLA/scuttle/issues/33